### PR TITLE
Handle expired certificates

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/transparencyreport_test.go
+++ b/transparencyreport_test.go
@@ -2,6 +2,7 @@ package transparencyreport
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -71,4 +72,16 @@ func TestCertsResponseUnmarshalJSON(t *testing.T) {
 	require.Equal(t, 10, len(response.Certs))
 	require.Equal(t, "J2RTFJ1CV6XFaVJXgAhwdWhCSytSPx5Hm+dv6C3RgPo\u003d", response.Certs[0].Hash)
 	require.Equal(t, "79lm2oVushsShS9ZtJlnvBlRj8hvM+TeR9eHPo+T7dU\u003d", response.Certs[9].Hash)
+
+	// Thu Aug 02 2018 14:28:05 GMT+0000
+	date := time.Date(2018, time.August, 02, 14, 28, 05, 00, time.UTC)
+	if !response.Certs[9].NotBefore.UTC().Equal(date) {
+		t.Errorf("%s != %s", response.Certs[9].NotBefore.UTC(), date)
+	}
+
+	// Wed Oct 31 2018 14:28:05 GMT+0000
+	date = time.Date(2018, time.October, 31, 14, 28, 05, 00, time.UTC)
+	if !response.Certs[9].NotAfter.UTC().Equal(date) {
+		t.Errorf("%s != %s", response.Certs[9].NotAfter.UTC(), date)
+	}
 }


### PR DESCRIPTION
Hello there!

As you may have noticed, Google has remove the **include_expired** option of the transparency report 'API'.

This PR handle the issue by managing the **include_expired** on the client side, by doing two things:

- Check that the certificates is not expired before appending it to the result array.
- Prevent fetching of pages full of expired certificates, by checking if the current page has only expired certs. (this behaviour has been tested, and looks correct).

I will perform some other checks on our end, and let you know if everything's fine.

In the meantime, here's the PR :)

Have a good one.